### PR TITLE
Update Pagination.php

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -509,7 +509,7 @@ class CI_Pagination {
 				$this->uri_segment = count($this->CI->uri->segment_array());
 			}
 
-			$this->cur_page = $this->CI->uri->segment($this->uri_segment);
+			$this->cur_page = $this->CI->uri->segment($this->uri_segment, '');
 
 			// Remove any specified prefix/suffix from the segment.
 			if ($this->prefix !== '' OR $this->suffix !== '')


### PR DESCRIPTION
fix str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated